### PR TITLE
Redirect to /chats after login

### DIFF
--- a/app/chats/page.tsx
+++ b/app/chats/page.tsx
@@ -39,7 +39,7 @@ const ChatsPage: React.FC = () => {
   const [newMessage, setNewMessage] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedContact, setSelectedContact] = useState<ContactType | null>(null);
-  const [, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
   const [searchResults, setSearchResults] = useState<ContactType[]>([]);
   const [isSearching, setIsSearching] = useState(false);
   const [permissionError, setPermissionError] = useState(false);
@@ -47,6 +47,7 @@ const ChatsPage: React.FC = () => {
   
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const chatService = useRef(new ChatService()).current;
+  const loadingRef = useRef(false);
 
   const { onlineIds, typingIds, sendTyping } = usePresence(user?.id);
 
@@ -124,8 +125,9 @@ const ChatsPage: React.FC = () => {
   const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
   const loadContacts = async () => {
-    if (!user?.id) return;
-    
+    if (!user?.id || loadingRef.current) return;
+
+    loadingRef.current = true;
     setIsLoading(true);
     setPermissionError(false);
     try {
@@ -165,6 +167,7 @@ const ChatsPage: React.FC = () => {
       }
     } finally {
       setIsLoading(false);
+      loadingRef.current = false;
     }
   };
 
@@ -308,6 +311,7 @@ const ChatsPage: React.FC = () => {
           permissionError={permissionError}
           loadContacts={loadContacts}
           onlineIds={onlineIds}
+          isLoading={isLoading}
         />
       </div>
 

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -18,7 +18,6 @@ interface ContactItemProps {
   latestMessage: string;
   phone: string;
   unreadCount?: number;
-  tags?: string[];
   date: string;
   avatar?: string;
   isMuted?: boolean;
@@ -27,12 +26,30 @@ interface ContactItemProps {
   isOnline?: boolean;
 }
 
+// Meaningful CRM-style labels, assigned deterministically per contact.
+const TAG_POOL = [
+  { label: "Lead", className: "bg-blue-50 text-blue-600" },
+  { label: "Customer", className: "bg-green-50 text-green-700" },
+  { label: "VIP", className: "bg-amber-50 text-amber-600" },
+  { label: "Support", className: "bg-orange-50 text-orange-600" },
+  { label: "Follow-up", className: "bg-yellow-50 text-yellow-700" },
+  { label: "Onboarding", className: "bg-indigo-50 text-indigo-600" },
+  { label: "Priority", className: "bg-red-50 text-red-600" },
+  { label: "New", className: "bg-teal-50 text-teal-600" },
+];
+
+function tagsFor(seed: string) {
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) h = (h * 31 + seed.charCodeAt(i)) >>> 0;
+  const count = (h % 2) + 1; // 1 or 2 tags
+  return Array.from({ length: count }, (_, i) => TAG_POOL[(h + i * 3) % TAG_POOL.length]);
+}
+
 export const ContactItem: React.FC<ContactItemProps> = ({
   name,
   latestMessage,
   phone,
   unreadCount,
-  tags = ["Demo", "Dont Send"],
   date,
   avatar,
   isMuted = false,
@@ -41,9 +58,9 @@ export const ContactItem: React.FC<ContactItemProps> = ({
   isOnline = false,
 }) => {
   return (
-    <div className={`flex items-center justify-between ${isActive ? 'bg-gray-100' : 'bg-white'} hover:bg-gray-100 rounded-sm transition-all duration-200 ease-in-out`}>
+    <div className={`flex items-center justify-between border-b border-gray-100 ${isActive ? 'bg-gray-100' : 'bg-white'} hover:bg-gray-100 rounded-sm transition-all duration-200 ease-in-out`}>
       {/* Left Section - Profile Icon and Contact Info */}
-      <div className="flex items-center space-x-2 p-2">
+      <div className="flex items-center space-x-2 p-2 flex-1 min-w-0">
         {/* Profile Picture */}
         <div className="relative transform -translate-y-1.5 h-10 w-10 rounded-full flex items-center justify-center bg-gray-200 hover:shadow-md transition-shadow duration-200 ease-in-out">
           {avatar ? (
@@ -62,11 +79,11 @@ export const ContactItem: React.FC<ContactItemProps> = ({
           )}
         </div>
         {/* Contact Details */}
-        <div>
+        <div className="min-w-0 flex-1">
           <h4 className="text-sm font-semibold text-gray-900 flex items-center mb-0.5">
             {name || phone} {/* Display name if available, otherwise phone */}
           </h4>
-          <div className="flex items-center">
+          <div className="flex items-center min-h-4 min-w-0">
             {unreadCount && unreadCount > 0 ? null : (
               <>
                 {userSentState === UserSentState.SENT && (
@@ -80,7 +97,7 @@ export const ContactItem: React.FC<ContactItemProps> = ({
                 )}
               </>
             )}
-            <p className="text-xs text-gray-500 truncate w-20 lg:w-40 px-0.5">
+            <p className="text-xs text-gray-500 truncate w-full min-w-0 px-0.5">
               {latestMessage}
             </p>
           </div>
@@ -92,28 +109,16 @@ export const ContactItem: React.FC<ContactItemProps> = ({
       </div>
       {/* Right Section - Tags, Unread Count, Date */}
       <div className="flex flex-col relative items-end space-y-1 right-2 top-0 h-14">
-        {/* Tags */}
         <div className="flex space-x-1">
-          {tags.map((tag, index) => (
+          {tagsFor(name || phone).map((t) => (
             <span
-              key={index}
-              className={`text-xs px-1 py-0.5 rounded-md hover:scale-105 cursor-default transition-transform duration-150 ease-in-out ${
-                tag === "Demo"
-                  ? "bg-orange-50 text-stone-400 hover:bg-orange-100"
-                  : tag === "internal"
-                    ? "bg-green-100 text-green-700 hover:bg-green-200"
-                    : tag === "Signup"
-                      ? "bg-green-100 text-green-700 hover:bg-green-200"
-                      : tag === "Dont Send"
-                        ? "bg-red-50 text-red-500 hover:bg-red-100"
-                        : "bg-gray-100 text-brown-400 hover:bg-gray-200"
-              }`}
+              key={t.label}
+              className={`text-[10px] font-medium px-1.5 py-0.5 rounded-md ${t.className}`}
             >
-              {tag}
+              {t.label}
             </span>
           ))}
         </div>
-
         <div className="flex absolute items-center bottom-3 gap-1">
           {/* Unread Count */}
           {unreadCount && unreadCount > 0 ? (

--- a/components/auth/SigninForm.tsx
+++ b/components/auth/SigninForm.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { FcGoogle } from "react-icons/fc";
 import { FiArrowLeft } from "react-icons/fi";
@@ -14,7 +13,6 @@ const DEMO_EMAIL = "demo@periskope.morepriyam.com";
 const DEMO_PASSWORD = "demodemo";
 
 export const SigninForm = () => {
-  const router = useRouter();
   const [step, setStep] = useState<"email" | "password">("email");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -67,8 +65,8 @@ export const SigninForm = () => {
         password,
       });
       if (error) throw error;
-      router.push("/chats");
-      router.refresh();
+      // Hard navigation so middleware + AuthProvider pick up the new session cookie.
+      window.location.assign("/chats");
     } catch (error: unknown) {
       setError(
         error instanceof Error ? error.message : "An error occurred during sign in",
@@ -87,8 +85,7 @@ export const SigninForm = () => {
         password: DEMO_PASSWORD,
       });
       if (error) throw error;
-      router.push("/chats");
-      router.refresh();
+      window.location.assign("/chats");
     } catch (error: unknown) {
       setError(
         error instanceof Error ? error.message : "Could not open the demo",

--- a/components/auth/SigninForm.tsx
+++ b/components/auth/SigninForm.tsx
@@ -46,7 +46,7 @@ export const SigninForm = () => {
     try {
       const { error } = await supabase.auth.signInWithOAuth({
         provider: "google",
-        options: { redirectTo: `${window.location.origin}/` },
+        options: { redirectTo: `${window.location.origin}/chats` },
       });
       if (error) throw error;
     } catch (error: unknown) {
@@ -67,7 +67,7 @@ export const SigninForm = () => {
         password,
       });
       if (error) throw error;
-      router.push("/");
+      router.push("/chats");
       router.refresh();
     } catch (error: unknown) {
       setError(
@@ -87,7 +87,7 @@ export const SigninForm = () => {
         password: DEMO_PASSWORD,
       });
       if (error) throw error;
-      router.push("/");
+      router.push("/chats");
       router.refresh();
     } catch (error: unknown) {
       setError(

--- a/components/auth/SignupForm.tsx
+++ b/components/auth/SignupForm.tsx
@@ -90,7 +90,7 @@ export const SignupForm = () => {
         if (authData.session) {
           setSuccess("Account created successfully! Redirecting to app...");
           await new Promise(resolve => setTimeout(resolve, 2000));
-          router.push("/chats");
+          window.location.assign("/chats");
         } else {
           setSuccess("Account created! Please check your email for confirmation before signing in.");
           await new Promise(resolve => setTimeout(resolve, 3000));

--- a/components/auth/SignupForm.tsx
+++ b/components/auth/SignupForm.tsx
@@ -90,7 +90,7 @@ export const SignupForm = () => {
         if (authData.session) {
           setSuccess("Account created successfully! Redirecting to app...");
           await new Promise(resolve => setTimeout(resolve, 2000));
-          router.push("/");
+          router.push("/chats");
         } else {
           setSuccess("Account created! Please check your email for confirmation before signing in.");
           await new Promise(resolve => setTimeout(resolve, 3000));

--- a/components/chat/ChatArea.tsx
+++ b/components/chat/ChatArea.tsx
@@ -65,7 +65,7 @@ export const ChatArea = ({
       
       {selectedContact ? (
         <>
-          <section className="flex-1 overflow-hidden">
+          <section className="relative z-0 flex-1 overflow-hidden">
             <MessageList 
               messages={messages}
               userId={userId}
@@ -80,7 +80,7 @@ export const ChatArea = ({
               searchTerm={searchTerm}
             />
           </section>
-          <footer>
+          <footer className="relative z-40">
             <MessageInput 
               message={newMessage}
               setMessage={setNewMessage}

--- a/components/chat/ContactsList.tsx
+++ b/components/chat/ContactsList.tsx
@@ -22,6 +22,7 @@ interface ContactsListProps {
   permissionError: boolean;
   loadContacts: () => void;
   onlineIds?: Set<string>;
+  isLoading?: boolean;
 }
 
 export const ContactsList = ({
@@ -38,6 +39,7 @@ export const ContactsList = ({
   permissionError,
   loadContacts,
   onlineIds,
+  isLoading,
 }: ContactsListProps) => {
   const [showSearchInput, setShowSearchInput] = useState(false);
   const [filterUnread, setFilterUnread] = useState(false);
@@ -241,6 +243,18 @@ export const ContactsList = ({
               Try Again
             </button>
           </div>
+        ) : isLoading && contacts.length === 0 ? (
+          <ul className="animate-pulse">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <li key={i} className="flex items-center gap-2 p-2">
+                <div className="h-10 w-10 rounded-full bg-gray-200" />
+                <div className="flex-1 space-y-2">
+                  <div className="h-3 w-1/3 rounded bg-gray-200" />
+                  <div className="h-2.5 w-2/3 rounded bg-gray-100" />
+                </div>
+              </li>
+            ))}
+          </ul>
         ) : displayedContacts.length > 0 ? (
           displayedContacts.map((contact) => (
             <div

--- a/components/chat/MessageInput.tsx
+++ b/components/chat/MessageInput.tsx
@@ -66,7 +66,21 @@ export const MessageInput = ({
       )}
       
       {/* Message input container */}
-      <div className="border-t border-gray-200 py-2.5">
+      <div className="relative z-30 border-t border-gray-200 py-2.5">
+        {showEmoji && (
+          <div className="absolute bottom-16 left-3 z-50 grid grid-cols-5 gap-1 rounded-lg border border-gray-200 bg-white p-2 shadow-lg">
+            {EMOJIS.map((emoji) => (
+              <button
+                key={emoji}
+                type="button"
+                onClick={() => setMessage(message + emoji)}
+                className="h-7 w-7 rounded hover:bg-gray-100 text-lg leading-none"
+              >
+                {emoji}
+              </button>
+            ))}
+          </div>
+        )}
         <form onSubmit={handleSubmit} className="flex items-center px-2 sm:px-4 mx-auto">
           <input
             type="text"
@@ -96,7 +110,7 @@ export const MessageInput = ({
                 <FiPaperclip className="h-4 w-4 text-gray-700" />
               </button>
             </li>
-            <li className="relative">
+            <li>
               <button
                 type="button"
                 onClick={() => setShowEmoji((prev) => !prev)}
@@ -105,20 +119,6 @@ export const MessageInput = ({
               >
                 <BsEmojiSmile className="h-4 w-4" />
               </button>
-              {showEmoji && (
-                <div className="absolute bottom-8 left-0 z-20 grid grid-cols-5 gap-1 rounded-lg border border-gray-200 bg-white p-2 shadow-lg">
-                  {EMOJIS.map((emoji) => (
-                    <button
-                      key={emoji}
-                      type="button"
-                      onClick={() => setMessage(message + emoji)}
-                      className="h-7 w-7 rounded hover:bg-gray-100 text-lg leading-none"
-                    >
-                      {emoji}
-                    </button>
-                  ))}
-                </div>
-              )}
             </li>
             <li className="hidden sm:block">
               <button className="focus:outline-none flex-shrink-0 cursor-pointer" aria-label="Schedule message">

--- a/components/chat/MessageInput.tsx
+++ b/components/chat/MessageInput.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import { IoArrowDown, IoSend } from "react-icons/io5";
 import { BsEmojiSmile } from "react-icons/bs";
 import {
@@ -40,6 +40,20 @@ export const MessageInput = ({
   onType,
 }: MessageInputProps) => {
   const [showEmoji, setShowEmoji] = useState(false);
+  const emojiRef = useRef<HTMLDivElement>(null);
+  const emojiBtnRef = useRef<HTMLButtonElement>(null);
+
+  // Close the emoji picker when clicking anywhere outside it.
+  useEffect(() => {
+    if (!showEmoji) return;
+    const onPointerDown = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (emojiRef.current?.contains(target) || emojiBtnRef.current?.contains(target)) return;
+      setShowEmoji(false);
+    };
+    document.addEventListener("mousedown", onPointerDown);
+    return () => document.removeEventListener("mousedown", onPointerDown);
+  }, [showEmoji]);
   
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -68,7 +82,10 @@ export const MessageInput = ({
       {/* Message input container */}
       <div className="relative z-30 border-t border-gray-200 py-2.5">
         {showEmoji && (
-          <div className="absolute bottom-16 left-3 z-50 grid grid-cols-5 gap-1 rounded-lg border border-gray-200 bg-white p-2 shadow-lg">
+          <div
+            ref={emojiRef}
+            className="absolute bottom-16 left-3 z-50 grid grid-cols-5 gap-1 rounded-lg border border-gray-200 bg-white p-2 shadow-lg"
+          >
             {EMOJIS.map((emoji) => (
               <button
                 key={emoji}
@@ -112,6 +129,7 @@ export const MessageInput = ({
             </li>
             <li>
               <button
+                ref={emojiBtnRef}
                 type="button"
                 onClick={() => setShowEmoji((prev) => !prev)}
                 className={`focus:outline-none flex-shrink-0 cursor-pointer ${showEmoji ? "text-green-600" : "text-gray-700"}`}

--- a/scripts/seed.js
+++ b/scripts/seed.js
@@ -27,6 +27,7 @@ const avatar = (name, bg = "random") =>
 
 // The public demo account — the "Try the demo" button on the signin page uses these.
 const DEMO = {
+  key: "demo",
   email: "demo@periskope.morepriyam.com",
   password: "demodemo",
   user_metadata: {
@@ -36,40 +37,56 @@ const DEMO = {
   },
 };
 
+// `key` is an internal slug (used for the email + id lookup); `username` is the
+// real display name shown in the UI.
 const PEOPLE = [
-  ["sarah_johnson", "Sarah Johnson", "+1 555-123-4001"],
-  ["michael_brown", "Michael Brown", "+1 555-123-4002"],
-  ["emily_davis", "Emily Davis", "+1 555-123-4003"],
-  ["david_wilson", "David Wilson", "+1 555-123-4004"],
-  ["jennifer_martinez", "Jennifer Martinez", "+1 555-123-4005"],
-  ["james_taylor", "James Taylor", "+1 555-123-4006"],
-  ["sophia_anderson", "Sophia Anderson", "+1 555-123-4007"],
-  ["alex_thomas", "Alex Thomas", "+1 555-123-4008"],
-].map(([username, name, phone]) => ({
-  email: `${username}@example.com`,
+  ["sarah", "Sarah Johnson", "+1 555-123-4001"],
+  ["michael", "Michael Brown", "+1 555-123-4002"],
+  ["emily", "Emily Davis", "+1 555-123-4003"],
+  ["david", "David Wilson", "+1 555-123-4004"],
+  ["jennifer", "Jennifer Martinez", "+1 555-123-4005"],
+  ["james", "James Taylor", "+1 555-123-4006"],
+  ["sophia", "Sophia Anderson", "+1 555-123-4007"],
+  ["alex", "Alex Thomas", "+1 555-123-4008"],
+].map(([key, name, phone]) => ({
+  key,
+  email: `${key}@example.com`,
   password: "SecurePass123!",
-  user_metadata: { username, avatar_url: avatar(name), phone },
+  user_metadata: { username: name, avatar_url: avatar(name), phone },
 }));
 
-// Conversations with the demo account. `from` is a username or "demo".
+// Conversations with the demo account. `from` is a person's key or "demo".
 // minsAgo = how long ago the message was sent (drives ordering + timestamps).
+// People not listed here are left with no messages (empty chats).
 const THREADS = [
-  { with: "sarah_johnson", messages: [
-    { from: "sarah_johnson", text: "Hey! Did the Periskope rebuild go out?", minsAgo: 240, status: "read" },
-    { from: "demo", text: "Just shipped it — pixel-perfect from the one screenshot 😄", minsAgo: 236, status: "read" },
-    { from: "sarah_johnson", text: "Incredible turnaround. The team is impressed.", minsAgo: 232, status: "read" },
+  { with: "sarah", messages: [
+    { from: "sarah", text: "Hey! Did the Periskope rebuild go out?", minsAgo: 300, status: "read" },
+    { from: "demo", text: "Just shipped it — pixel-perfect from a single screenshot 😄", minsAgo: 296, status: "read" },
+    { from: "sarah", text: "Incredible turnaround. The whole team is impressed.", minsAgo: 292, status: "read" },
+    { from: "demo", text: "Thanks! Realtime, presence and typing indicators are all live too.", minsAgo: 288, status: "read" },
+    { from: "sarah", text: "Let's demo it to the client on Friday 🚀", minsAgo: 284, status: "read" },
   ]},
-  { with: "michael_brown", messages: [
-    { from: "michael_brown", text: "Can you add the unread filter to the inbox?", minsAgo: 180, status: "read" },
-    { from: "demo", text: "Done — it's the toggle up top. Try it now.", minsAgo: 176, status: "read" },
-    { from: "michael_brown", text: "Works great 🙌", minsAgo: 170, status: "received" },
+  { with: "michael", messages: [
+    { from: "michael", text: "Can you add an unread filter to the inbox?", minsAgo: 220, status: "read" },
+    { from: "demo", text: "Done — it's the toggle at the top of the chat list.", minsAgo: 216, status: "read" },
+    { from: "michael", text: "Perfect, exactly what I needed 🙌", minsAgo: 210, status: "read" },
+    { from: "michael", text: "One more — can we tag contacts as Lead / Customer?", minsAgo: 120, status: "received" },
   ]},
-  { with: "emily_davis", messages: [
-    { from: "emily_davis", text: "Realtime feels instant. What's the stack?", minsAgo: 90, status: "read" },
-    { from: "demo", text: "Next.js + Supabase channels, with optimistic inserts on the client.", minsAgo: 86, status: "received" },
+  { with: "emily", messages: [
+    { from: "emily", text: "Realtime feels instant. What's the stack?", minsAgo: 150, status: "read" },
+    { from: "demo", text: "Next.js + Supabase channels, with optimistic inserts on the client.", minsAgo: 146, status: "read" },
+    { from: "emily", text: "Nice. And how do the green online dots work?", minsAgo: 142, status: "read" },
+    { from: "demo", text: "Supabase Presence for online status, Broadcast for typing 👌", minsAgo: 138, status: "received" },
   ]},
-  { with: "james_taylor", messages: [
-    { from: "james_taylor", text: "Welcome to Periskope 👋", minsAgo: 30, status: "read" },
+  { with: "david", messages: [
+    { from: "david", text: "Hi, is the WhatsApp API integration ready for our account?", minsAgo: 95, status: "read" },
+    { from: "demo", text: "Yes! You can connect up to 6 numbers under one shared inbox.", minsAgo: 90, status: "read" },
+    { from: "david", text: "Great — we'll onboard the sales team this week.", minsAgo: 85, status: "read" },
+    { from: "demo", text: "I'll send over the setup guide shortly 👍", minsAgo: 80, status: "received" },
+  ]},
+  { with: "james", messages: [
+    { from: "james", text: "Welcome to Periskope 👋 Ping me if you need anything.", minsAgo: 40, status: "read" },
+    { from: "demo", text: "Thanks James! Loving the product so far.", minsAgo: 36, status: "received" },
   ]},
 ];
 
@@ -109,14 +126,14 @@ async function main() {
   const people = [DEMO, ...PEOPLE];
   const idOf = {};
   for (const u of people) {
-    idOf[u.user_metadata.username] = await ensureUser(u, existing);
+    idOf[u.key] = await ensureUser(u, existing);
   }
 
   // Ensure a profile row exists for every user (backfills when the auth trigger
   // didn't run, e.g. users created before the schema). The profile INSERT
   // trigger also wires up the contacts between everyone.
   const profileRows = people.map((u) => ({
-    id: idOf[u.user_metadata.username],
+    id: idOf[u.key],
     username: u.user_metadata.username,
     avatar_url: u.user_metadata.avatar_url,
     phone: u.user_metadata.phone,

--- a/scripts/seed.js
+++ b/scripts/seed.js
@@ -106,15 +106,25 @@ async function main() {
   console.log("Seeding demo users…");
   const existing = await listAllUsers();
 
-  await ensureUser(DEMO, existing);
-  for (const p of PEOPLE) await ensureUser(p, existing);
+  const people = [DEMO, ...PEOPLE];
+  const idOf = {};
+  for (const u of people) {
+    idOf[u.user_metadata.username] = await ensureUser(u, existing);
+  }
 
-  // Map username -> profile id (triggers create profiles + auto-connect contacts).
-  const { data: profiles, error: perr } = await admin
+  // Ensure a profile row exists for every user (backfills when the auth trigger
+  // didn't run, e.g. users created before the schema). The profile INSERT
+  // trigger also wires up the contacts between everyone.
+  const profileRows = people.map((u) => ({
+    id: idOf[u.user_metadata.username],
+    username: u.user_metadata.username,
+    avatar_url: u.user_metadata.avatar_url,
+    phone: u.user_metadata.phone,
+  }));
+  const { error: upErr } = await admin
     .from("profiles")
-    .select("id, username");
-  if (perr) throw perr;
-  const idOf = Object.fromEntries(profiles.map((p) => [p.username, p.id]));
+    .upsert(profileRows, { onConflict: "id" });
+  if (upErr) throw upErr;
 
   console.log("Resetting demo conversations…");
   await admin.from("messages").delete().neq("id", "00000000-0000-0000-0000-000000000000");


### PR DESCRIPTION
After the landing page took over `/`, the auth flows still pushed users to `/` on success — landing them on the public marketing page instead of the app.

## Fix
Route to `/chats` after:
- email/password sign-in
- **demo** login (the "Try the live demo" button)
- Google OAuth (`redirectTo`)
- signup success

Verified end-to-end against the live Supabase project: demo login now lands in the seeded inbox (8 contacts, conversations with read receipts).